### PR TITLE
Fix token image bugs

### DIFF
--- a/src/components/main_box/MainBox.scss
+++ b/src/components/main_box/MainBox.scss
@@ -57,7 +57,7 @@
       @include min-breakpoint(700px){
         height: 80vh;
       }
-      @include min-breakpoint(1200px){
+      @include min-breakpoint(768px){
         min-height: auto;
         display: none;
       }
@@ -88,10 +88,15 @@
           height: 400px;
           width: 180px;
         }
-        @include min-breakpoint(900px) {
+        @include min-breakpoint(768px) {
+          background-size: 400px;
+          height: 400px;
+          top: 380px;
+          width: 100px;
+        }
+        @include min-breakpoint(1080px) {
           background-size: 550px;
           height: 550px;
-          width: 255px;
         }
         @include min-breakpoint(1200px) {
           background-size: 550px;

--- a/src/components/mission/Mission.scss
+++ b/src/components/mission/Mission.scss
@@ -7,26 +7,46 @@
   margin-top: $base-space-size * 9;
   text-align: left;
   text-align: start;
-  @include min-breakpoint(1200px){
-    height: 860px;
+  @include min-breakpoint(768px){
+    height: 450px;
     position: relative;
     text-align: right;
+    padding-right: 50px;
+    padding-top: 150px;
+    max-width: 1070px;
+  }
+  @include min-breakpoint(1080px){
+    height: 700px;
+  }
+  @include min-breakpoint(1200px){
+    height: 860px;
+    padding-right: 0;
     padding-top: 220px;
     max-width: 1070px;
   }
   .token-image{
     display: none;
-    @include min-breakpoint(1200px){
+    @include min-breakpoint(768px){
       display: block;
       background-size: auto 100%;
       background-repeat: no-repeat;
       background-position: left center;
-      width: 1060px;
-      height: 1000px;
+      width: 628px;
+      height: 592px;
       position: absolute;
+      left: -200px;
+      top: -200px;
+      z-index: -1;
+    }
+    @include min-breakpoint(1080px){
+      width: 940px;
+      height: 867px;
       left: -400px;
       top: -187px;
-      z-index: -1;
+    }
+    @include min-breakpoint(1200px){
+      width: 1060px;
+      height: 1000px;
     }
   }
   &__title {
@@ -49,11 +69,17 @@
       font-size: $font-size-title-h5;
     }
   }
+  @include min-breakpoint(768px) {
+    &__text {
+      text-align: right;
+      display: inline-block;
+      max-width: 350px;
+    }
+  }
   @include min-breakpoint(1200px) {
     &__text {
       font-size: 26px;
-      text-align: right;
-      display: inline-block;
+      max-width: 430px;
     }
   }
   //@include min-breakpoint(700px) {

--- a/src/components/static_picture/StaticPicture.scss
+++ b/src/components/static_picture/StaticPicture.scss
@@ -9,4 +9,7 @@
   @include iPhone() {
     background-attachment: scroll;
   }
+  @include iPad() {
+    background-attachment: scroll;
+  }
 }

--- a/src/core/styles/breakpoints.scss
+++ b/src/core/styles/breakpoints.scss
@@ -90,6 +90,134 @@
   }
 }
 
+/* ----------- iPad 1, 2, Mini and Air ----------- */
+
+@mixin iPad12MiniAir() {
+  /* Portrait and Landscape */
+  @media only screen 
+    and (min-device-width: 768px) 
+    and (max-device-width: 1024px) 
+    and (-webkit-min-device-pixel-ratio: 1) {
+      @content;
+  }
+
+  /* Portrait */
+  @media only screen 
+    and (min-device-width: 768px) 
+    and (max-device-width: 1024px) 
+    and (orientation: portrait) 
+    and (-webkit-min-device-pixel-ratio: 1) {
+      @content;
+  }
+
+  /* Landscape */
+  @media only screen 
+    and (min-device-width: 768px) 
+    and (max-device-width: 1024px) 
+    and (orientation: landscape) 
+    and (-webkit-min-device-pixel-ratio: 1) {
+      @content;
+  }
+}
+
+/* ----------- iPad 3, 4 and Pro 9.7" ----------- */
+
+@mixin iPad34Pro97() {
+  /* Portrait and Landscape */
+  @media only screen 
+    and (min-device-width: 768px) 
+    and (max-device-width: 1024px) 
+    and (-webkit-min-device-pixel-ratio: 2) {
+      @content;
+  }
+
+  /* Portrait */
+  @media only screen 
+    and (min-device-width: 768px) 
+    and (max-device-width: 1024px) 
+    and (orientation: portrait) 
+    and (-webkit-min-device-pixel-ratio: 2) {
+      @content;
+  }
+
+  /* Landscape */
+  @media only screen 
+    and (min-device-width: 768px) 
+    and (max-device-width: 1024px) 
+    and (orientation: landscape) 
+    and (-webkit-min-device-pixel-ratio: 2) {
+      @content;
+  }
+}
+
+/* ----------- iPad Pro 10.5" ----------- */
+
+@mixin iPadPro105() {
+  /* Portrait and Landscape */
+  @media only screen 
+    and (min-device-width: 834px) 
+    and (max-device-width: 1112px)
+    and (-webkit-min-device-pixel-ratio: 2) {
+      @content;
+  }
+
+  /* Portrait */
+  /* Declare the same value for min- and max-width to avoid colliding with desktops */
+  /* Source: https://medium.com/connect-the-dots/css-media-queries-for-ipad-pro-8cad10e17106*/
+  @media only screen 
+    and (min-device-width: 834px) 
+    and (max-device-width: 834px) 
+    and (orientation: portrait) 
+    and (-webkit-min-device-pixel-ratio: 2) {
+      @content;
+  }
+
+  /* Landscape */
+  /* Declare the same value for min- and max-width to avoid colliding with desktops */
+  /* Source: https://medium.com/connect-the-dots/css-media-queries-for-ipad-pro-8cad10e17106*/
+  @media only screen 
+    and (min-device-width: 1112px) 
+    and (max-device-width: 1112px) 
+    and (orientation: landscape) 
+    and (-webkit-min-device-pixel-ratio: 2) {
+      @content;
+  }
+}
+
+/* ----------- iPad Pro 12.9" ----------- */
+
+@mixin iPad129() {
+  /* Portrait and Landscape */
+  @media only screen 
+    and (min-device-width: 1024px) 
+    and (max-device-width: 1366px)
+    and (-webkit-min-device-pixel-ratio: 2) {
+      @content;
+  }
+
+  /* Portrait */
+  /* Declare the same value for min- and max-width to avoid colliding with desktops */
+  /* Source: https://medium.com/connect-the-dots/css-media-queries-for-ipad-pro-8cad10e17106*/
+  @media only screen 
+    and (min-device-width: 1024px) 
+    and (max-device-width: 1024px) 
+    and (orientation: portrait) 
+    and (-webkit-min-device-pixel-ratio: 2) {
+      @content;
+  }
+
+  /* Landscape */
+  /* Declare the same value for min- and max-width to avoid colliding with desktops */
+  /* Source: https://medium.com/connect-the-dots/css-media-queries-for-ipad-pro-8cad10e17106*/
+  @media only screen 
+    and (min-device-width: 1366px) 
+    and (max-device-width: 1366px) 
+    and (orientation: landscape) 
+    and (-webkit-min-device-pixel-ratio: 2) {
+      @content;
+  }
+}
+
 @mixin iPhone() {
   @include iPhone234() {
     @content;
@@ -101,6 +229,21 @@
     @content;
   }
   @include iPhoneX() {
+    @content;
+  }
+}
+
+@mixin iPad() {
+  @include iPad12MiniAir() {
+    @content;
+  }
+  @include iPad34Pro97() {
+    @content;
+  }
+  @include iPadPro105() {
+    @content;
+  }
+  @include iPad129() {
     @content;
   }
 }


### PR DESCRIPTION
I changed the CSS on the main page to have the image turn into the token shape on Ipad by adding a breakpoint for 768px width and adjusting spacing accordingly.
I also added a mixin for Ipads to fix the image scaling issue by changing the background-attachment to scroll.
I deployed to firebase :)