### PR TITLE
Add padding-top to statement

### DIFF
--- a/src/components/certificates/Certificates.scss
+++ b/src/components/certificates/Certificates.scss
@@ -105,6 +105,7 @@
       display: flex;
       align-items: center;
       justify-content: center;
+      padding-top: 50px;
       @include breakpoint('xs'){
         flex-flow: row wrap;
       }


### PR DESCRIPTION
I added padding to the top of the statement section to have more space under the form.
This refers to Trello card: https://trello.com/c/WZIwRwT3/77-more-space-under-quote-pictures-and-form
I deployed to firebase.  Let me know if you want more space!