### PR TITLE
align certificate impact text left, move impact photo

### DIFF
--- a/src/components/certificates/Certificates.scss
+++ b/src/components/certificates/Certificates.scss
@@ -90,6 +90,7 @@
         justify-content: center;
         align-items: center;
         min-height: 60vh;
+        overflow: hidden;
       }
       @include min-breakpoint(700px){
         justify-content: left;

--- a/src/components/certificates/Certificates.scss
+++ b/src/components/certificates/Certificates.scss
@@ -92,9 +92,9 @@
         min-height: 60vh;
       }
       @include min-breakpoint(700px){
-        justify-content: center;
+        justify-content: left;
         min-height: 60vh;
-        padding-left: 100px;
+        padding-left: 6%;
       }
       @include breakpoint(1199px){
         padding-left: 10%;

--- a/src/components/certificates/Certificates.tsx
+++ b/src/components/certificates/Certificates.tsx
@@ -73,8 +73,8 @@ class MainBox extends React.Component {
               pictures={this.props.pictures}
               picturePosition="right"
               pictureName="student-token-pic"
-              pictureWidth={1040}
-              pictureHeight={960}
+              pictureWidth={1150}
+              pictureHeight={1050}
               scalePicture={true}
               textVerticalAlignement="top"
               extraModules={[SignupButton(this.props.texts)]}

--- a/src/components/certificates/Certificates.tsx
+++ b/src/components/certificates/Certificates.tsx
@@ -73,8 +73,8 @@ class MainBox extends React.Component {
               pictures={this.props.pictures}
               picturePosition="right"
               pictureName="student-token-pic"
-              pictureWidth={950}
-              pictureHeight={905}
+              pictureWidth={1040}
+              pictureHeight={960}
               scalePicture={true}
               textVerticalAlignement="top"
               extraModules={[SignupButton(this.props.texts)]}

--- a/src/components/impact_picture_section/ImpactPictureSection.scss
+++ b/src/components/impact_picture_section/ImpactPictureSection.scss
@@ -46,7 +46,7 @@
         left: -400px;
       }
       &__right {
-        right: -400px;
+        right: -330px;
       }
     }
   }

--- a/src/components/impact_picture_section/ImpactPictureSection.scss
+++ b/src/components/impact_picture_section/ImpactPictureSection.scss
@@ -46,7 +46,7 @@
         left: -400px;
       }
       &__right {
-        right: -400px;
+        right: -550px;
       }
     }
   }

--- a/src/components/impact_picture_section/ImpactPictureSection.scss
+++ b/src/components/impact_picture_section/ImpactPictureSection.scss
@@ -36,7 +36,7 @@
       background-size: auto 100%;
       background-repeat: no-repeat;
       background-position: left center;
-      width: 950px;
+      width: 1040px;
       height: 1000px;
       position: absolute;
       top: 0px;
@@ -46,7 +46,7 @@
         left: -400px;
       }
       &__right {
-        right: -330px;
+        right: -400px;
       }
     }
   }


### PR DESCRIPTION
- padding-left on the impact text now matches the padding left on the button above it
- moved impact photo left instead of increasing size; it's already much bigger than text area