### PR TITLE
Make token image always scroll

### DIFF
--- a/src/components/certificates/Certificates.scss
+++ b/src/components/certificates/Certificates.scss
@@ -85,6 +85,7 @@
     }
 
     &--ngo {
+      background-color: white;
       display: flex;
       @include min-breakpoint(1200px){
         justify-content: center;
@@ -113,7 +114,7 @@
 
     &--picture{
       position: relative;
-      height: 100vh;
+      height: 400px;
       min-height: auto;
       overflow: hidden;
       &:after{
@@ -125,7 +126,7 @@
         top: 5px;
       }
       @include min-breakpoint(700px){
-        height: 80vh;
+        height: 60vh;
       }
       @include min-breakpoint(1200px){
         min-height: auto;

--- a/src/components/certificates/Certificates.scss
+++ b/src/components/certificates/Certificates.scss
@@ -11,6 +11,15 @@
 }
 
 .Certificates {
+  &__container {
+    background-color: white;
+    padding: 1px 0;  // Added to prevent margin collapse
+    @include min-breakpoint(1200px) {
+      background-color: rgba(0,0,0,0);
+      padding: 0;
+    }
+  }
+
   .subscriptionSignupForm {
     @include breakpoint(1200px){
       margin-top: 0px;
@@ -88,6 +97,7 @@
       background-color: white;
       display: flex;
       @include min-breakpoint(1200px){
+        background-color: rgba(0,0,0,0);
         justify-content: center;
         align-items: center;
         min-height: 60vh;

--- a/src/components/certificates/Certificates.tsx
+++ b/src/components/certificates/Certificates.tsx
@@ -46,11 +46,13 @@ class MainBox extends React.Component {
 
     return (
       <div className={parentClass}>
-        <Section name="home" fullHeight={true} parentClass={parentClass}>
-          <TextFetcher id="certificates-hero-text" texts={this.props.texts}>
-            <CertificateHome text={emptyText}/>
-          </TextFetcher>
-        </Section>
+        <div className="MainBox__container">
+          <Section name="home" fullHeight={true} parentClass={parentClass}>
+            <TextFetcher id="certificates-hero-text" texts={this.props.texts}>
+              <CertificateHome text={emptyText}/>
+            </TextFetcher>
+          </Section>
+        </div>
         <Section name="picture" fullWidth={true} parentClass={parentClass}>
           <PictureFetcher
             cropHeight={viewport => viewport.height}
@@ -81,16 +83,18 @@ class MainBox extends React.Component {
             />
           </TextFetcher>
         </Section>
-        <Section name="statement" parentClass={parentClass}>
-          <TextFetcher id="statement-opportunities" texts={this.props.texts}>
-            <Statement
-              pictures={this.props.pictures}
-              text={emptyText}
-              pictureNames={['statement-man', 'statement-woman']}
-              textVerticalAlignement="top"
-            />
-          </TextFetcher>
-        </Section>
+        <div className="MainBox__container">
+          <Section name="statement" parentClass={parentClass}>
+            <TextFetcher id="statement-opportunities" texts={this.props.texts}>
+              <Statement
+                pictures={this.props.pictures}
+                text={emptyText}
+                pictureNames={['statement-man', 'statement-woman']}
+                textVerticalAlignement="top"
+              />
+            </TextFetcher>
+          </Section>
+        </div>
       </div>
     );
   }

--- a/src/components/certificates/Certificates.tsx
+++ b/src/components/certificates/Certificates.tsx
@@ -46,7 +46,7 @@ class MainBox extends React.Component {
 
     return (
       <div className={parentClass}>
-        <div className="MainBox__container">
+        <div className="Certificates__container">
           <Section name="home" fullHeight={true} parentClass={parentClass}>
             <TextFetcher id="certificates-hero-text" texts={this.props.texts}>
               <CertificateHome text={emptyText}/>
@@ -83,7 +83,7 @@ class MainBox extends React.Component {
             />
           </TextFetcher>
         </Section>
-        <div className="MainBox__container">
+        <div className="Certificates__container">
           <Section name="statement" parentClass={parentClass}>
             <TextFetcher id="statement-opportunities" texts={this.props.texts}>
               <Statement

--- a/src/components/footer/Footer.scss
+++ b/src/components/footer/Footer.scss
@@ -2,6 +2,7 @@
 @import "../../core/styles/base";
 
 .Footer {
+  background-color: white;
   background-image: url('../../../graphics/footer/Webpage_Diwala_Mobile.png');
   background-repeat: no-repeat;
   background-position: center bottom;
@@ -24,6 +25,14 @@
     background-image: url('../../../graphics/footer/Bubble_rightside-06.png');
     background-position: right bottom;
     background-size: auto;
+  }
+  &__container {
+    background-color: white;
+    display: flex;
+    @include min-breakpoint(768px) {
+      background-color: rgba(0,0,0,0);
+      display: static;
+    }
   }
   &__diwala-icon {
     width: 120px;
@@ -131,7 +140,7 @@
     }
   }
   // icon moving around
-  margin-top: 190px;
+  margin-top: 42px;
   position: relative;
   &:before {
     background-image: url("../../../graphics/Diwala_Logo-13.png");

--- a/src/components/footer/Footer.scss
+++ b/src/components/footer/Footer.scss
@@ -140,8 +140,11 @@
     }
   }
   // icon moving around
-  margin-top: 42px;
+  margin-top: 190px;
   position: relative;
+  @include min-breakpoint(490px) {
+    margin-top: 42px;
+  }
   &:before {
     background-image: url("../../../graphics/Diwala_Logo-13.png");
     background-position: left top;

--- a/src/components/footer/Footer.scss
+++ b/src/components/footer/Footer.scss
@@ -29,7 +29,7 @@
   &__container {
     background-color: white;
     display: flex;
-    @include min-breakpoint(768px) {
+    @include min-breakpoint(1200px) {
       background-color: rgba(0,0,0,0);
       display: static;
     }

--- a/src/components/footer/Footer.tsx
+++ b/src/components/footer/Footer.tsx
@@ -14,18 +14,21 @@ const Footer = function(props: any) {
   const color = '#5d05a7';
 
   return (
-      <footer className="Footer" id="footer">
-        {props.children}
-        <div className="Footer__bottom">
-          <div className="Footer__social-icons">
-            <SocialIcons urls={urls} color={color}/>
+      <div className="Footer__container">
+        <footer className="Footer" id="footer">
+          {props.children}
+          <div className="Footer__bottom">
+            <div className="Footer__social-icons">
+              <SocialIcons urls={urls} color={color}/>
+            </div>
+            <img className="Footer__logo" src={logo} alt="Diwala"/>
+            <div className="Footer__copyright">
+              Copyright © by Diwala. All rights reserved
+            </div>
           </div>
-          <img className="Footer__logo" src={logo} alt="Diwala"/>
-          <div className="Footer__copyright">
-            Copyright © by Diwala. All rights reserved
-          </div>
-        </div>
-      </footer>
+        </footer>
+      </div>
+      
   );
 };
 

--- a/src/components/main_box/MainBox.scss
+++ b/src/components/main_box/MainBox.scss
@@ -11,6 +11,15 @@
 }
 
 .MainBox {
+  &__container {
+    background-color: white;
+    padding: 1px 0;  // Added to prevent margin collapse
+    @include min-breakpoint(768px) {
+      background-color: rgba(0,0,0,0);
+      padding: 0;
+    }
+  }
+
   &__section {
     //padding: 0 $base-space-size * 2;
     min-height: 100vh;
@@ -39,7 +48,7 @@
 
     &--picture{
       position: relative;
-      height: 100vh;
+      height: 400px;
       min-height: auto;
       overflow: hidden;
       &:after{
@@ -54,8 +63,8 @@
         right: 5px;
         top: 5px;
       }
-      @include min-breakpoint(700px){
-        height: 80vh;
+      @include min-breakpoint(600px){
+        height: 60vh;
       }
       @include min-breakpoint(768px){
         min-height: auto;

--- a/src/components/main_box/MainBox.tsx
+++ b/src/components/main_box/MainBox.tsx
@@ -44,16 +44,18 @@ class MainBox extends React.Component {
     const parentClass = 'MainBox';
     return (
       <div className={parentClass}>
-        <Section name="home" fullHeight={true} parentClass={parentClass}>
-          <TextFetcher id="hero-text" texts={this.props.texts}>
-            <Home text={emptyText}/>
-          </TextFetcher>
-        </Section>
-        <Section name="benefits" parentClass={parentClass}>
-          <TextFetcher id="benefits" texts={this.props.texts}>
-            <Benefits text={emptyText} pictures={this.props.pictures}/>
-          </TextFetcher>
-        </Section>
+        <div className="MainBox__container">
+          <Section name="home" fullHeight={true} parentClass={parentClass}>
+            <TextFetcher id="hero-text" texts={this.props.texts}>
+              <Home text={emptyText}/>
+            </TextFetcher>
+          </Section>
+          <Section name="benefits" parentClass={parentClass}>
+            <TextFetcher id="benefits" texts={this.props.texts}>
+              <Benefits text={emptyText} pictures={this.props.pictures}/>
+            </TextFetcher>
+          </Section>
+        </div>
         <Section name="picture" fullWidth={true} parentClass={parentClass}>
           <PictureFetcher
             cropHeight={viewport => viewport.height}
@@ -68,28 +70,30 @@ class MainBox extends React.Component {
               width={0}/>
           </PictureFetcher>
         </Section>
-        <Section name="missionAndPartners" parentClass={parentClass}>
-          <div id="mission">
-            <TextFetcher id="frontpage-missionstatement" texts={this.props.texts}>
-              <Mission  pictures={this.props.pictures} text={emptyText}/>
-            </TextFetcher>
-          </div>
-          <div id="partners">
-            <Filter if={this.props.partners}>
-              <Partners partners={this.props.partners}/>
+        <div className="MainBox__container">
+          <Section name="missionAndPartners" parentClass={parentClass}>
+            <div id="mission">
+              <TextFetcher id="frontpage-missionstatement" texts={this.props.texts}>
+                <Mission  pictures={this.props.pictures} text={emptyText}/>
+              </TextFetcher>
+            </div>
+            <div id="partners">
+              <Filter if={this.props.partners}>
+                <Partners partners={this.props.partners}/>
+              </Filter>
+            </div>
+          </Section>
+          <Section name="support" parentClass={parentClass}>
+            <div id="support">
+              <DonationSection />
+            </div>
+          </Section>
+          <Section name="team" parentClass={parentClass}>
+            <Filter if={this.props.team}>
+              <Team team={this.props.team}/>
             </Filter>
-          </div>
-        </Section>
-        <Section name="support" parentClass={parentClass}>
-          <div id="support">
-            <DonationSection />
-          </div>
-        </Section>
-        <Section name="team" parentClass={parentClass}>
-          <Filter if={this.props.team}>
-            <Team team={this.props.team}/>
-          </Filter>
-        </Section>
+          </Section>
+        </div>
       </div>
     );
   }

--- a/src/components/static_picture/StaticPicture.scss
+++ b/src/components/static_picture/StaticPicture.scss
@@ -1,15 +1,21 @@
 @import "../../core/styles/utilities";
 
 .static-picture {
-  background-position: center center;
+  background-position: center;
+  position: fixed; /* stretch a fixed position to the whole screen */
+  top: 0;
+  height: 100vh; /* fix for mobile browser address bar appearing disappearing */
+  left: 0;
+  right: 0;
+  z-index: -1; /* needed to keep in the background */
+
+  -webkit-background-size: cover;
+  -moz-background-size: cover;
+  -o-background-size: cover;
   background-size: cover;
-  @include min-breakpoint(700px) {
-    background-attachment: fixed;
-  }
-  @include iPhone() {
-    background-attachment: scroll;
-  }
-  @include iPad() {
-    background-attachment: scroll;
+
+  @include min-breakpoint(768px) {
+    position: static;
+    height: inherit;
   }
 }

--- a/src/components/static_picture/StaticPicture.scss
+++ b/src/components/static_picture/StaticPicture.scss
@@ -13,9 +13,22 @@
   -moz-background-size: cover;
   -o-background-size: cover;
   background-size: cover;
+}
 
-  @include min-breakpoint(768px) {
-    position: static;
-    height: inherit;
+.MainBox {
+  .static-picture {
+    @include min-breakpoint(768px) {
+      position: static;
+      height: inherit;
+    }
+  }
+}
+
+.Certificates {
+  .static-picture {
+    @include min-breakpoint(1200px) {
+      position: static;
+      height: inherit;
+    }
   }
 }


### PR DESCRIPTION
I came up with one solution to get the image to be fixed on mobile.  To get it to work, I needed to put the main boxes and footer in containers to give them a white background & I needed to add one 1px padding to prevent the margins from collapsing so everything would appear white on top of the fixed image.

Please let me know what you think.  I checked it on my phone, and it now has the image as fixed instead of scrolling.

I deployed to Firebase.

Trello Card:  https://trello.com/c/KjV912l9/85-make-token-static-picture-not-static-on-all-clients