### PR TITLE
Increase CSS specificity so cancel button removed after submitting

### DIFF
--- a/src/components/certificates/Certificates.scss
+++ b/src/components/certificates/Certificates.scss
@@ -52,6 +52,10 @@
       width: 150px;
     }
 
+    .response-form ~ .subscription-signup-button {
+      display: none;
+    }
+
     .subscription-signup-button.displayed{
       opacity: 1;
     }

--- a/src/components/certificates/Certificates.scss
+++ b/src/components/certificates/Certificates.scss
@@ -52,10 +52,6 @@
       width: 150px;
     }
 
-    .response-form ~ .subscription-signup-button {
-      display: none;
-    }
-
     .subscription-signup-button.displayed{
       opacity: 1;
     }
@@ -101,6 +97,9 @@
       min-height: 90vh;
       background-color: white;
       display: flex;
+      @include min-breakpoint(490px){
+        padding-bottom: 100px;
+      }
       @include min-breakpoint(1200px){
         background-color: rgba(0,0,0,0);
         justify-content: center;

--- a/src/components/certificates/subscription_form/SubscriptionForm.scss
+++ b/src/components/certificates/subscription_form/SubscriptionForm.scss
@@ -64,7 +64,7 @@
   @include button;
 }
 
-.App .Certificates .subscriptionSignupForm .open ~ .subscription-signup-button {
+.App .Certificates .subscriptionSignupForm .response-form ~ .subscription-signup-button {
   display: none;
 }
 
@@ -75,4 +75,8 @@
 .message {
   font-size: 15px;
   margin-bottom: 35px;
+}
+
+.response-form .restart-button {
+  max-width: 200px;
 }

--- a/src/components/certificates/subscription_form/SubscriptionForm.scss
+++ b/src/components/certificates/subscription_form/SubscriptionForm.scss
@@ -64,7 +64,7 @@
   @include button;
 }
 
-.response-form ~ .subscription-signup-button{
+.App .Certificates .subscriptionSignupForm .open ~ .subscription-signup-button {
   display: none;
 }
 


### PR DESCRIPTION
The reason why the cancel button wasn't display none when the form was submitted was because there was higher CSS specificity coming from 

Certificates.scss Line 50:
.open ~ .subscription-signup-button {
      @include invert_button;
      width: 150px;
    }

The invert_button included a display flex that was overriding the display none.

To fix it, I increased the CSS specificity for the 

.response-form ~ .subscription-signup-button {
      display: none;
    }

by putting it in the nested CSS in the Certificates.scss file instead of just the SubscriptionForm.scss file.  I also increase the specificity in the SubscriptionForm.scss which is redundant, but I was keeping it since other form CSS is in that file.

I deployed to deploy-dev-1.

This is for Trello card:  https://trello.com/c/K8nXcxIy/97-minor-signup-form-bugs
