### PR TITLE
Make logo clickable

### DIFF
--- a/src/components/header/Header.scss
+++ b/src/components/header/Header.scss
@@ -14,6 +14,7 @@ $header-total-height: $header-height + $header-padding * 2;
   left: 0;
   right: 0;
   width: 100%;
+  z-index: 1;
 
   &__logo{
     width: 130px;


### PR DESCRIPTION
I changed the z-index for the header to 1 and that made it clickable again.

I deployed to deploy-dev-2

This refers to Trello card:  https://trello.com/c/s4vo82GE/96-logo-is-not-clickable-so-not-linkable-back-home-lays-behind-the-mainbox